### PR TITLE
Update Dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ barcodeScanning = "17.2.0"
 buffer = "1.3.6"
 cameraX = "1.2.3"
 compose = "1.5.2"
-zxing-core = "3.5.2"
 decompose = "2.2.0-compose-experimental-alpha01"
 encoding-base32 = "2.0.0"
 essenty = "1.3.0-alpha01"
@@ -40,6 +39,7 @@ version-catalog-update = "0.8.1"
 # @keep
 versionCode = "10"
 webcamCapture = "0.3.12"
+zxing-core = "3.5.2"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
@@ -52,8 +52,6 @@ androidx-cameraPreview = { module = "androidx.camera:camera-view", version.ref =
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core-ktx" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-crypto" }
 buffer = { module = "com.ditchoom:buffer", version.ref = "buffer" }
-zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
-zxing-javase = { module = "com.google.zxing:javase", version.ref = "zxing-core" }
 decompose = { module = "com.arkivanov.decompose:decompose", version.ref = "decompose" }
 decompose-extensionsComposeJetbrains = { module = "com.arkivanov.decompose:extensions-compose-jetbrains", version.ref = "decompose" }
 encoding-base32 = { module = "io.matthewnelson.encoding:base32", version.ref = "encoding-base32" }
@@ -78,6 +76,8 @@ parcelize-darwinRuntime = { module = "com.arkivanov.parcelize.darwin:runtime", v
 uriKmp = { module = "com.eygraber:uri-kmp", version.ref = "uri-kmp" }
 uuid = { module = "com.benasher44:uuid", version.ref = "uuid" }
 webcam-capture = { module = "com.github.sarxos:webcam-capture", version.ref = "webcamCapture" }
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
+zxing-javase = { module = "com.google.zxing:javase", version.ref = "zxing-core" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradle-plugin" }


### PR DESCRIPTION
The following dependencies are using the latest milestone version:
 - androidx.annotation:annotation:1.6.0
 - androidx.annotation:annotation-experimental:1.3.0
 - androidx.annotation:annotation-jvm:1.6.0
 - androidx.appcompat:appcompat:1.6.1
 - androidx.appcompat:appcompat-resources:1.6.1
 - androidx.arch.core:core-common:2.2.0
 - androidx.arch.core:core-runtime:2.2.0
 - androidx.autofill:autofill:1.0.0
 - androidx.camera:camera-camera2:1.2.3
 - androidx.camera:camera-core:1.2.3
 - androidx.camera:camera-lifecycle:1.2.3
 - androidx.camera:camera-view:1.2.3
 - androidx.collection:collection:1.1.0
 - androidx.compose.animation:animation:1.5.0
 - androidx.compose.animation:animation-android:1.5.0
 - androidx.compose.animation:animation-core:1.5.0
 - androidx.compose.animation:animation-core-android:1.5.0
 - androidx.compose.animation:animation-graphics:1.5.0
 - androidx.compose.animation:animation-graphics-android:1.5.0
 - androidx.compose.foundation:foundation:1.5.0
 - androidx.compose.foundation:foundation-android:1.5.0
 - androidx.compose.foundation:foundation-layout:1.5.0
 - androidx.compose.foundation:foundation-layout-android:1.5.0
 - androidx.compose.material:material-icons-core:1.5.0
 - androidx.compose.material:material-icons-core-android:1.5.0
 - androidx.compose.material:material-icons-extended:1.5.0
 - androidx.compose.material:material-icons-extended-android:1.5.0
 - androidx.compose.material:material-ripple:1.5.0
 - androidx.compose.material:material-ripple-android:1.5.0
 - androidx.compose.material3:material3:1.1.1
 - androidx.compose.runtime:runtime:1.5.0
 - androidx.compose.runtime:runtime-android:1.5.0
 - androidx.compose.runtime:runtime-saveable:1.5.0
 - androidx.compose.runtime:runtime-saveable-android:1.5.0
 - androidx.compose.ui:ui:1.5.0
 - androidx.compose.ui:ui-android:1.5.0
 - androidx.compose.ui:ui-geometry:1.5.0
 - androidx.compose.ui:ui-geometry-android:1.5.0
 - androidx.compose.ui:ui-graphics:1.5.0
 - androidx.compose.ui:ui-graphics-android:1.5.0
 - androidx.compose.ui:ui-text:1.5.0
 - androidx.compose.ui:ui-text-android:1.5.0
 - androidx.compose.ui:ui-unit:1.5.0
 - androidx.compose.ui:ui-unit-android:1.5.0
 - androidx.compose.ui:ui-util:1.5.0
 - androidx.compose.ui:ui-util-android:1.5.0
 - androidx.concurrent:concurrent-futures:1.1.0
 - androidx.core:core:1.12.0
 - androidx.core:core-ktx:1.12.0
 - androidx.cursoradapter:cursoradapter:1.0.0
 - androidx.customview:customview:1.0.0
 - androidx.customview:customview-poolingcontainer:1.0.0
 - androidx.drawerlayout:drawerlayout:1.0.0
 - androidx.emoji2:emoji2:1.4.0
 - androidx.emoji2:emoji2-views-helper:1.4.0
 - androidx.exifinterface:exifinterface:1.3.2
 - androidx.fragment:fragment:1.3.6
 - androidx.fragment:fragment-ktx:1.1.0
 - androidx.interpolator:interpolator:1.0.0
 - androidx.lifecycle:lifecycle-common:2.6.1
 - androidx.lifecycle:lifecycle-common-java8:2.6.1
 - androidx.lifecycle:lifecycle-livedata:2.6.1
 - androidx.lifecycle:lifecycle-livedata-core:2.6.1
 - androidx.lifecycle:lifecycle-process:2.6.1
 - androidx.lifecycle:lifecycle-runtime:2.6.1
 - androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
 - androidx.lifecycle:lifecycle-viewmodel:2.6.1
 - androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
 - androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
 - androidx.loader:loader:1.0.0
 - androidx.profileinstaller:profileinstaller:1.3.0
 - androidx.resourceinspection:resourceinspection-annotation:1.0.1
 - androidx.savedstate:savedstate:1.2.1
 - androidx.savedstate:savedstate-ktx:1.2.1
 - androidx.startup:startup-runtime:1.1.1
 - androidx.tracing:tracing:1.0.0
 - androidx.vectordrawable:vectordrawable:1.1.0
 - androidx.vectordrawable:vectordrawable-animated:1.1.0
 - androidx.versionedparcelable:versionedparcelable:1.1.1
 - androidx.viewpager:viewpager:1.0.0
 - co.touchlab:kermit-android:2.0.0-RC5
 - co.touchlab:kermit-core-android:2.0.0-RC5
 - com.arkivanov.decompose:decompose-android:2.2.0-compose-experimental-alpha01
 - com.arkivanov.decompose:extensions-compose-jetbrains-android:2.2.0-compose-experimental-alpha01
 - com.arkivanov.essenty:back-handler-android:1.3.0-alpha01
 - com.arkivanov.essenty:instance-keeper-android:1.3.0-alpha01
 - com.arkivanov.essenty:lifecycle-android:1.3.0-alpha01
 - com.arkivanov.essenty:parcelable-android:1.3.0-alpha01
 - com.arkivanov.essenty:state-keeper-android:1.3.0-alpha01
 - com.arkivanov.essenty:utils-internal-android:1.3.0-alpha01
 - com.arkivanov.parcelize.darwin:com.arkivanov.parcelize.darwin.gradle.plugin:0.2.2
 - com.arkivanov.parcelize.darwin:compiler-plugin:0.2.2
 - com.arkivanov.parcelize.darwin:runtime:0.2.2
 - com.benasher44:uuid:0.8.1
 - com.benasher44:uuid-jvm:0.8.1
 - com.ditchoom:buffer:1.3.6
 - com.ditchoom:buffer-android:1.3.6
 - com.eygraber:uri-kmp:0.0.15
 - com.eygraber:uri-kmp-android:0.0.15
 - com.eygraber:uri-kmp-android-debug:0.0.15
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.48.0
 - com.github.sarxos:webcam-capture:0.3.12
 - com.google.accompanist:accompanist-permissions:0.32.0
 - com.google.accompanist:accompanist-systemuicontroller:0.32.0
 - com.google.android.datatransport:transport-api:2.2.1
 - com.google.android.datatransport:transport-backend-cct:2.3.3
 - com.google.android.datatransport:transport-runtime:2.2.6
 - com.google.android.gms:play-services-base:18.1.0
 - com.google.android.gms:play-services-basement:18.1.0
 - com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.0
 - com.google.android.gms:play-services-tasks:18.0.2
 - com.google.auto.value:auto-value-annotations:1.6.3
 - com.google.code.gson:gson:2.8.9
 - com.google.crypto.tink:tink-android:1.7.0
 - com.google.firebase:firebase-annotations:16.0.0
 - com.google.firebase:firebase-components:16.1.0
 - com.google.firebase:firebase-encoders:16.1.0
 - com.google.firebase:firebase-encoders-json:17.1.0
 - com.google.guava:listenablefuture:1.0
 - com.google.mlkit:barcode-scanning:17.2.0
 - com.google.mlkit:barcode-scanning-common:17.0.0
 - com.google.mlkit:common:18.9.0
 - com.google.mlkit:vision-common:17.3.0
 - com.google.mlkit:vision-interfaces:16.2.0
 - com.google.zxing:core:3.5.2
 - com.google.zxing:javase:3.5.2
 - com.russhwolf:multiplatform-settings:1.0.0
 - com.russhwolf:multiplatform-settings-android:1.0.0
 - com.russhwolf:multiplatform-settings-android-debug:1.0.0
 - dev.icerock.mobile.multiplatform-resources:dev.icerock.mobile.multiplatform-resources.gradle.plugin:0.23.0
 - dev.icerock.moko:graphics:0.9.0
 - dev.icerock.moko:graphics-android:0.9.0
 - dev.icerock.moko:graphics-android-debug:0.9.0
 - dev.icerock.moko:parcelize:0.8.0
 - dev.icerock.moko:parcelize-android:0.8.0
 - dev.icerock.moko:parcelize-android-debug:0.8.0
 - dev.icerock.moko:resources:0.23.0
 - dev.icerock.moko:resources-android:0.23.0
 - dev.icerock.moko:resources-compose:0.23.0
 - dev.icerock.moko:resources-compose-android:0.23.0
 - io.github.aakira:napier:1.4.1
 - io.github.aakira:napier-android:1.4.1
 - io.github.aakira:napier-android-debug:1.4.1
 - io.insert-koin:koin-compose:1.1.0
 - io.insert-koin:koin-compose-jvm:1.1.0
 - io.insert-koin:koin-core:3.5.0
 - io.insert-koin:koin-core-jvm:3.5.0
 - io.matthewnelson.encoding:base32:2.0.0
 - io.matthewnelson.encoding:base32-jvm:2.0.0
 - io.matthewnelson.encoding:core:2.0.0
 - io.matthewnelson.encoding:core-jvm:2.0.0
 - javax.inject:javax.inject:1
 - junit:junit:4.13.2
 - nl.littlerobots.version-catalog-update:nl.littlerobots.version-catalog-update.gradle.plugin:0.8.1
 - org.hamcrest:hamcrest-core:1.3
 - org.jetbrains:annotations:23.0.0
 - org.jetbrains.compose:org.jetbrains.compose.gradle.plugin:1.5.2
 - org.jetbrains.compose.animation:animation-graphics:1.5.2
 - org.jetbrains.compose.compiler:compiler:1.5.2
 - org.jetbrains.compose.components:components-resources:1.5.2
 - org.jetbrains.compose.components:library-android:1.5.2
 - org.jetbrains.compose.desktop:desktop:1.5.2
 - org.jetbrains.compose.desktop:desktop-jvm-linux-x64:1.5.2
 - org.jetbrains.compose.foundation:foundation:1.5.2
 - org.jetbrains.compose.material:material-icons-extended:1.5.2
 - org.jetbrains.compose.material3:material3:1.5.2
 - org.jetbrains.compose.runtime:runtime:1.5.2
 - org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.9.10
 - org.jetbrains.kotlin:kotlin-build-tools-impl:1.9.10
 - org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.10
 - org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:1.9.10
 - org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10
 - org.jetbrains.kotlin:kotlin-reflect:1.8.20
 - org.jetbrains.kotlin:kotlin-stdlib:1.9.10
 - org.jetbrains.kotlin:kotlin-stdlib-common:1.9.10
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10
 - org.jetbrains.kotlin:kotlin-test:1.9.10
 - org.jetbrains.kotlin:kotlin-test-junit:1.9.10
 - org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.9.10
 - org.jetbrains.kotlin.plugin.parcelize:org.jetbrains.kotlin.plugin.parcelize.gradle.plugin:1.9.10
 - org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin:1.9.10
 - org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3
 - org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3
 - org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3
 - org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3
 - org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.7.3
 - org.jetbrains.kotlinx:kotlinx-datetime:0.4.1
 - org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.4.1
 - org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.0
 - org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.0
 - org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.6.0
 - org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0
 - org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.6.0
 - org.kotlincrypto.core:common:0.3.0
 - org.kotlincrypto.core:common-jvm:0.3.0
 - org.kotlincrypto.core:digest:0.3.0
 - org.kotlincrypto.core:digest-jvm:0.3.0
 - org.kotlincrypto.core:mac:0.3.0
 - org.kotlincrypto.core:mac-jvm:0.3.0
 - org.kotlincrypto.hash:sha1:0.3.0
 - org.kotlincrypto.hash:sha1-jvm:0.3.0
 - org.kotlincrypto.hash:sha2:0.3.0
 - org.kotlincrypto.hash:sha2-jvm:0.3.0
 - org.kotlincrypto.macs:hmac:0.3.0
 - org.kotlincrypto.macs:hmac-jvm:0.3.0
 - org.kotlincrypto.macs:hmac-sha1:0.3.0
 - org.kotlincrypto.macs:hmac-sha1-jvm:0.3.0
 - org.kotlincrypto.macs:hmac-sha2:0.3.0
 - org.kotlincrypto.macs:hmac-sha2-jvm:0.3.0

The following dependencies have later milestone versions:
 - com.android.application:com.android.application.gradle.plugin [8.1.0 -> 8.1.2]
     https://developer.android.com/studio/build
 - com.android.library:com.android.library.gradle.plugin [8.1.0 -> 8.1.2]
     https://developer.android.com/studio/build
 - org.apache.logging.log4j:log4j-core [2.17.1 -> 2.20.0]
     https://logging.apache.org/log4j/2.x/
 - org.jetbrains:annotations [13.0 -> 23.0.0]
     http://www.jetbrains.org
 - org.jetbrains.kotlin:kotlin-stdlib [1.8.20 -> 1.9.10]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-common [1.8.20 -> 1.9.10]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7 [1.8.20 -> 1.9.10]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8 [1.8.20 -> 1.9.10]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-test [1.9.0 -> 1.9.10]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-test-junit [1.9.0 -> 1.9.10]
     https://kotlinlang.org/

Failed to determine the latest version for the following dependencies (use --info for details):
 - androidx.activity:activity
     1.8.0-rc01
 - androidx.activity:activity-compose
     1.8.0-rc01
 - androidx.activity:activity-ktx
     1.8.0-rc01
 - androidx.security:security-crypto
     1.1.0-alpha05
 - co.touchlab:kermit
     2.0.1
 - co.touchlab:kermit-android-debug
     2.0.1
 - co.touchlab:kermit-core
     2.0.1
 - co.touchlab:kermit-core-android-debug
     2.0.1
 - com.arkivanov.decompose:decompose
     2.2.0-compose-experimental-alpha01
 - com.arkivanov.decompose:decompose-android-debug
     2.2.0-compose-experimental-alpha01
 - com.arkivanov.decompose:extensions-compose-jetbrains
     2.2.0-compose-experimental-alpha01
 - com.arkivanov.decompose:extensions-compose-jetbrains-android-debug
     2.2.0-compose-experimental-alpha01
 - com.arkivanov.essenty:back-handler
     1.3.0-alpha01
 - com.arkivanov.essenty:back-handler-android-debug
     1.3.0-alpha01
 - com.arkivanov.essenty:instance-keeper
     1.3.0-alpha01
 - com.arkivanov.essenty:instance-keeper-android-debug
     1.3.0-alpha01
 - com.arkivanov.essenty:lifecycle
     1.3.0-alpha01
 - com.arkivanov.essenty:lifecycle-android-debug
     1.3.0-alpha01
 - com.arkivanov.essenty:parcelable
     1.3.0-alpha01
 - com.arkivanov.essenty:parcelable-android-debug
     1.3.0-alpha01
 - com.arkivanov.essenty:state-keeper
     1.3.0-alpha01
 - com.arkivanov.essenty:state-keeper-android-debug
     1.3.0-alpha01
 - com.arkivanov.essenty:utils-internal
     1.3.0-alpha01
 - com.arkivanov.essenty:utils-internal-android-debug
     1.3.0-alpha01
 - com.google.android.odml:image
     1.0.0-beta1

Gradle release-candidate updates:
 - Gradle: [8.2.1 -> 8.3 -> 8.4-rc-3]